### PR TITLE
docs: refresh README for idempotent API and runtime pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,194 +1,144 @@
 # FT Relay
 
-A Rust-powered HTTP relay that batches NEP-141 `ft_transfer` calls into NEAR transactions. Use it whenever you need to fan-in high volumes of fungible token transfers onto NEAR with a simple HTTP interface.
-
----
+A Rust-powered HTTP relay that batches NEP-141 `ft_transfer` calls into NEAR transactions. Designed for high-volume fan-in of fungible token transfers with a simple, idempotent HTTP API and a durable Redis-backed pipeline.
 
 ## Features
+- Idempotent HTTP ingestion – clients must provide `X-Idempotency-Key`, used as the stable `transfer_id`.
+- Registration, transfer, and verification workers (Redis Streams + consumer groups).
+- Micro-batching – up to 100 `ft_transfer` actions per transaction (3 Tgas per action, under NEAR’s 300 Tgas limit).
+- Signer key pool with nonce management backed by Redis.
+- Durable state and event logs in Redis with 24h TTL.
+- Docker and docker-compose ready; near-sandbox integration tests and benchmarks.
 
-- **Transfer endpoints** – `POST /v1/transfer` to queue transfers, `GET /v1/transfer/:id` to check status and get tx_hash.
-- **Signer pool** – rotate across multiple function-call access keys to avoid nonce contention.
-- **Micro-batching** – pack up to `BATCH_SIZE` transfers into a single transaction while respecting the 300 TGas ceiling.
-- **Async pipeline** – bounded queue + semaphore to backpressure inflight batches.
-- **Durable queue** – Redis Streams persist every transfer until the worker acknowledges it.
-- **Sandbox-friendly** – integration suites spin up `near-sandbox`, deploy the FT contract, and verify final balances.
-- **Docker-ready** – minimal two-stage container for production deployment.
-
----
-
-## Architecture at a Glance
-
+## Architecture
 ![ft-relay architecture diagram](docs/diagrams/architecture.svg)
 
-- The HTTP handler writes each request to a Redis Stream and immediately returns a `transfer_id`.
-- The async worker consumes from the stream’s consumer group, batches transfers, and submits NEAR transactions.
-- Gas accounting ensures we never exceed NEAR’s 300 TGas prepaid limit (`90` transfers × `40 TGas`).
-- The signer pool is backed by `near-api-rs` and can host multiple secret keys for high concurrency.
-
----
+- HTTP handler persists each request and enqueues it into Redis Streams.
+- Registration worker batches `storage_deposit` for unregistered receivers.
+- Transfer worker batches `ft_transfer` actions and submits a single NEAR transaction.
+- Verification worker confirms or requeues transfers based on final chain outcome.
+- Nonces and access key leases are coordinated via Redis.
 
 ## Prerequisites
+- Rust 1.86+
+- Redis 8+
+- NEAR RPC URL (sandbox/testnet/mainnet)
+- Optional for tests: near-sandbox (tests will fetch and run it)
 
-- [Rust](https://www.rust-lang.org/tools/install) 1.86 (pinned in CI).
-- `near-sandbox` dependencies (the integration tests download and run it automatically).
-- [Redis](https://redis.io/) 8 or newer, reachable from the relay.
+## Quickstart
+1) Configure
+```bash
+cp .env.example .env
+# Set ACCOUNT_ID, PRIVATE_KEYS, RPC_URL, REDIS_URL (optional), etc.
+```
 
----
+2) Run
+```bash
+cargo run --release -- --token your-ft-contract.testnet
+# Or export TOKEN=your-ft-contract.testnet and run without the flag
+```
+By default binds to `0.0.0.0:8080` (override via `BIND_ADDR`).
 
-## Getting Started
-
-1. **Clone and configure**
-
-   ```bash
-   git clone https://github.com/r-near/ft-relay.git
-   cd ft-relay
-
-   cp .env.example .env
-   # edit ACCOUNT_ID, PRIVATE_KEYS, RPC_URL, batching knobs
-   ```
-
-2. **Run the relay**
-
-   ```bash
-   cargo run --release -- \
-     --token your-ft-contract.testnet
-   ```
-
-   The server listens on `0.0.0.0:8080` unless you set `BIND_ADDR`.
-
-3. **Send a transfer**
+3) Try it
 ```bash
 curl -X POST http://localhost:8080/v1/transfer \
   -H 'Content-Type: application/json' \
+  -H 'X-Idempotency-Key: <your-unique-id>' \
   -d '{"receiver_id":"alice.testnet","amount":"1000000000000000000"}'
 ```
-Responses include a durable identifier you can poll later:
 
-```json
-{"status":"queued","transfer_id":"6b81f45e-5c7c-4c84-987d-3cf6c3e4232a"}
-```
-
----
-
-## Configuration (.env)
-
-All configuration except the FT contract ID comes from environment variables. The CLI flag `--token` remains mandatory so you can point the same deployment at different contracts.
-
-| Variable               | Required | Description                                                                                           |
-| ---------------------- | -------- | ----------------------------------------------------------------------------------------------------- |
-| `ACCOUNT_ID`           | Required | NEAR account that owns the function-call access keys.                                                 |
-| `PRIVATE_KEYS`         | Required | Comma-separated list of ed25519 secret keys (`ed25519:...`). Use multiple keys for higher throughput. |
-| `RPC_URL`              | Required | NEAR RPC endpoint (sandbox/testnet/mainnet).                                                          |
-| `BIND_ADDR`            | Optional | HTTP bind address (`0.0.0.0:8080` by default).                                                        |
-| `BATCH_SIZE`           | Optional | Max logical transfers per batch (default `90`).                                                       |
-| `BATCH_LINGER_MS`      | Optional | Max time to wait for a batch to fill (default `20ms`).                                                |
-| `MAX_INFLIGHT_BATCHES` | Optional | Inflight batch semaphore (default `200`).                                                             |
-| `RUST_LOG`             | Optional | Standard Rust logging spec (`info,ft_relay=info`).                                                    |
-| `REDIS_URL`            | Optional | Connection string for Redis (default `redis://127.0.0.1:6379`).                                       |
-| `REDIS_STREAM_KEY`     | Optional | Stream key for pending transfers (default `ftrelay:pending`).                                        |
-| `REDIS_CONSUMER_GROUP` | Optional | Consumer group name used by the batch worker (default `ftrelay:batcher`).                             |
-
-> Warning: Use function-call restricted keys that can only call your FT contract. Never ship full-access secrets in production.
-
----
-
-## API Reference
-
-### `POST /v1/transfer`
-
-**Body**
-
+Example response (201):
 ```json
 {
+  "transfer_id": "00000000-0000-0000-0000-000000000000",
+  "status": "QUEUED_REGISTRATION",
   "receiver_id": "alice.testnet",
   "amount": "1000000000000000000",
-  "memo": "optional"
+  "created_at": "2024-10-11T00:00:00Z",
+  "retry_count": 0
 }
 ```
 
-- `receiver_id` – NEAR account to receive tokens (must be registered).
-- `amount` – Stringified yocto-token amount.
-- `memo` – Optional memo forwarded to the FT contract.
-
-**Response**
-
-```json
-{
-  "status": "queued",
-  "transfer_id": "6b81f45e-5c7c-4c84-987d-3cf6c3e4232a"
-}
-```
-
-HTTP `503` signals the internal queue is saturated.
-
-### `GET /v1/transfer/:id`
-
-Query the status of a previously submitted transfer.
-
-**Request**
-
+Poll status:
 ```bash
-curl http://localhost:8080/v1/transfer/6b81f45e-5c7c-4c84-987d-3cf6c3e4232a
+curl http://localhost:8080/v1/transfer/00000000-0000-0000-0000-000000000000
 ```
 
-**Response (pending)**
-
-```json
-{
-  "transfer_id": "6b81f45e-5c7c-4c84-987d-3cf6c3e4232a",
-  "status": "pending"
-}
+Health:
+```bash
+curl http://localhost:8080/health
 ```
 
-**Response (completed)**
+## Configuration
+You can set these via environment variables; `--token` CLI flag or `TOKEN` env is required for the FT contract.
 
-```json
-{
-  "transfer_id": "6b81f45e-5c7c-4c84-987d-3cf6c3e4232a",
-  "status": "completed",
-  "tx_hash": "HMeo3DYSuAmXWxuTotFzWMac5bcePhHeRqfCDLRNBs9Y"
-}
+Required:
+- ACCOUNT_ID – NEAR account that owns the function-call keys
+- PRIVATE_KEYS – Comma-separated ed25519 secret keys for ACCOUNT_ID (use function-call restricted keys)
+- RPC_URL – NEAR RPC endpoint (sandbox/testnet/mainnet)
+- TOKEN – FT contract account (or pass via `--token`)
+
+Optional:
+- BIND_ADDR – HTTP bind address (default: `0.0.0.0:8080`)
+- REDIS_URL – Redis connection string (default: `redis://127.0.0.1:6379`)
+- BATCH_LINGER_MS – Max wait for batch fill in ms (default: `20`)
+- TRANSFER_WORKERS – Number of transfer workers (default: `1`)
+- REGISTRATION_WORKERS – Number of registration workers (default: `1`)
+- VERIFICATION_WORKERS – Number of verification workers (default: `1`)
+- RUST_LOG – e.g., `info,ft_relay=info,near_api=warn`
+
+Environment label used in Redis keys is inferred from `TOKEN`:
+- `*.testnet` → `testnet`
+- `*.near` → `mainnet`
+- otherwise → `sandbox`
+
+## API
+- POST `/v1/transfer`
+  - Headers: `X-Idempotency-Key` (required)
+  - Body: `{"receiver_id":"<account>", "amount":"<yocto>"}` (no memo support)
+  - 201 with `TransferResponse` on accept; 400 if header/body invalid
+
+- GET `/v1/transfer/{id}`
+  - Returns the current `TransferResponse` (may include `events`)
+
+- GET `/health`
+  - Returns Redis status and metrics like `rpc_calls_total`
+
+Status lifecycle:
+`RECEIVED` → `QUEUED_REGISTRATION` → `REGISTERED` → `QUEUED_TRANSFER` → `SUBMITTED` → `QUEUED_VERIFICATION` → `COMPLETED` (or `FAILED`).
+
+Events are stored per transfer with a 24h TTL.
+
+## Batching and Gas
+- `FT_TRANSFER_GAS_PER_ACTION = 3 Tgas`, `STORAGE_DEPOSIT_GAS_PER_ACTION = 5 Tgas`
+- Up to 100 transfer actions per transaction; linger (`BATCH_LINGER_MS`) controls batching latency/throughput.
+
+## Docker
+docker-compose:
+```bash
+docker-compose up --build
+# relay at :8080, Redis at :6379
 ```
-
-Status records are stored in Redis for 24 hours after completion.
-
----
-
-## Troubleshooting
-
-- **Sandbox kernel parameter warnings** – `near-sandbox` may warn about TCP buffer sizes on Linux. Adjust via `scripts/set_kernel_params.sh` if you need peak throughput.
-- **Nonce errors** – Add more keys to `PRIVATE_KEYS` or ensure the signer account isn’t used elsewhere.
-- **Gas exceeded** – The relay automatically chunks batches, but if you change `FT_TRANSFER_GAS_PER_ACTION`, keep `gas * BATCH_SIZE ≤ 300 TGas`.
-- **Redis connectivity** – The server returns `500` if it cannot enqueue into Redis; verify `REDIS_URL` and that the stream/group exist.
-
----
+Image entrypoint:
+```bash
+docker run --rm -p 8080:8080 --env-file .env \
+  ghcr.io/your-org/ft-relay:latest --token your-ft-contract.testnet
+```
 
 ## Testing
-
-The project includes comprehensive test suites:
-
-**Run all tests serially** (required to avoid Redis conflicts):
+Run tests serially (avoid Redis/sandbox conflicts):
 ```bash
 cargo test --all --locked -- --test-threads=1 --nocapture
 ```
-
-**Run ignored integration/benchmark tests serially**:
+Ignored integration/benchmark tests:
 ```bash
 cargo test --all --locked -- --ignored --nocapture --test-threads=1
 ```
 
-**Test types**:
-- **Unit tests** – Fast, in-memory validation
-- **Integration tests** – Sandbox-based with real NEAR nodes
-- **Testnet tests** – Live testnet benchmarks (require `TESTNET_RPC_URL` in `.env`)
+## Troubleshooting
+- 400 Missing `X-Idempotency-Key` – the header is required; do not reuse keys across distinct transfers.
+- Nonce/key contention – add more keys to `PRIVATE_KEYS` or ensure the signer account isn’t used elsewhere.
+- Redis connectivity – verify `REDIS_URL`; the server relies on Redis (no fallback).
+- Use function-call restricted keys to limit blast radius.
 
-> Warning: Always use `--test-threads=1` to run tests serially and avoid Redis/sandbox conflicts.
-
----
-
-## Roadmap & Caveats
-
-- **Redis is required** – If Redis is down, the relay rejects new transfers with HTTP 500. No fallback queue exists.
-- **No idempotency** – Duplicate requests create separate transfers. Callers must implement deduplication if needed.
-
-Contributions and issue reports are welcome!
+Security note: Never ship full-access keys in production; restrict to the FT contract’s methods.


### PR DESCRIPTION
This PR rewrites README to reflect the current implementation:\n\n- Require X-Idempotency-Key for POST /v1/transfer (idempotent ingestion)\n- Clarify required/optional env vars (TOKEN, ACCOUNT_ID, PRIVATE_KEYS, RPC_URL, REDIS_URL, etc.)\n- Document registration/transfer/verification workers, batching, and gas usage\n- Add Docker usage, health endpoint, testing guidance (serial runs), and troubleshooting\n\nNo code changes—documentation only.